### PR TITLE
DSPDC-725 Initial Commit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ val enumeratumVersion = "1.5.13"
 val logbackVersion = "1.2.3"
 val scioVersion = "0.8.0"
 
+val scalatestVersion = "3.1.0"
+
 lazy val `encode-ingest` = project
   .in(file("."))
   .enablePlugins(MonsterJadeDatasetPlugin)
@@ -18,5 +20,9 @@ lazy val `encode-ingest` = project
       "com.beachape" %% "enumeratum" % enumeratumVersion,
       "ch.qos.logback" % "logback-classic" % logbackVersion,
       "com.spotify" %% "scio-extra" % scioVersion,
-    )
+    ),
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % scalatestVersion,
+      "io.circe" %% "circe-literal" % MonsterJadeDatasetPlugin.CirceVersion,
+    ).map(_ % Test)
   )

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeEntity.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeEntity.scala
@@ -17,6 +17,8 @@ object EncodeEntity extends Enum[EncodeEntity] {
 
   case object Experiment extends EncodeEntity
 
+  case object FunctionalCharacterizationExperiment extends EncodeEntity
+
   case object File extends EncodeEntity
 
   case object Library extends EncodeEntity

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeExtractions.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeExtractions.scala
@@ -156,28 +156,15 @@ object EncodeExtractions {
     *
     * @param referenceField field in the input JSONs containing the IDs
     *                       to extract
-    * @param manyReferences whether or not `referenceField` is an array
     */
   def getIds(
-    referenceField: String,
-    manyReferences: Boolean
+    referenceField: String
   ): SCollection[JsonObject] => SCollection[String] =
     collection =>
       collection.flatMap { jsonObj =>
-        jsonObj(referenceField).toIterable.flatMap { referenceJson =>
-          val references = for {
-            refValues <- if (manyReferences) {
-              referenceJson.as[List[String]]
-            } else {
-              referenceJson.as[String].map { reference =>
-                List(reference)
-              }
-            }
-          } yield {
-            refValues
-          }
-          references.toOption
-        }.flatten
+        jsonObj(referenceField).flatMap { referenceJson =>
+          referenceJson.as[String].toOption
+        }.toIterable
       }.distinct
 
   /**

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -118,7 +118,7 @@ object ExtractionPipeline {
     extractLinkedEntities(
       entityToExtract = EncodeEntity.File,
       matchingField = "@id",
-      linkingEntities = SCollection.unionAll([experiments, fcExperiments]),
+      linkingEntities = SCollection.unionAll(List(experiments, fcExperiments)),
       linkedField = "dataset"
     )
 

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -118,7 +118,7 @@ object ExtractionPipeline {
     extractLinkedEntities(
       entityToExtract = EncodeEntity.File,
       matchingField = "@id",
-      linkingEntities = SCollection.unionAll(experiments, fcExperiments),
+      linkingEntities = SCollection.unionAll([experiments, fcExperiments]),
       linkedField = "dataset"
     )
 

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -108,7 +108,7 @@ object ExtractionPipeline {
       linkingEntities = replicates
     )
 
-    val fc_experiments = extractLinkedEntities(
+    val fcExperiments = extractLinkedEntities(
       entityToExtract = EncodeEntity.FunctionalCharacterizationExperiment,
       matchingField = "experiment",
       linkingEntities = replicates
@@ -118,15 +118,7 @@ object ExtractionPipeline {
     extractLinkedEntities(
       entityToExtract = EncodeEntity.File,
       matchingField = "@id",
-      linkingEntities = experiments,
-      linkedField = "dataset"
-    )
-
-    // don't need to use files apart from storing them, so we don't assign an output here
-    extractLinkedEntities(
-      entityToExtract = EncodeEntity.File,
-      matchingField = "@id",
-      linkingEntities = fc_experiments,
+      linkingEntities = SCollection.unionAll(experiments, fcExperiments),
       linkedField = "dataset"
     )
 

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -102,16 +102,22 @@ object ExtractionPipeline {
       linkedField = "library.accession"
     )
 
+    //[partition] that stream to separate [type=experiment]
+    // from [type=functional-characterization-experiment]
+    val (expReplicate, fcReplicate) = replicates.partition {
+      replicate => replicate("experiment").exists(experimentString => experimentString.equals("Experiment"))
+    }
+
     val experiments = extractLinkedEntities(
       entityToExtract = EncodeEntity.Experiment,
       matchingField = "experiment",
-      linkingEntities = replicates
+      linkingEntities = expReplicate
     )
 
     val fcExperiments = extractLinkedEntities(
       entityToExtract = EncodeEntity.FunctionalCharacterizationExperiment,
       matchingField = "experiment",
-      linkingEntities = replicates
+      linkingEntities = fcReplicate
     )
 
     // don't need to use files apart from storing them, so we don't assign an output here

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -108,11 +108,25 @@ object ExtractionPipeline {
       linkingEntities = replicates
     )
 
+    val fc_experiments = extractLinkedEntities(
+      entityToExtract = EncodeEntity.FunctionalCharacterizationExperiment,
+      matchingField = "experiment",
+      linkingEntities = replicates
+    )
+
     // don't need to use files apart from storing them, so we don't assign an output here
     extractLinkedEntities(
       entityToExtract = EncodeEntity.File,
       matchingField = "@id",
       linkingEntities = experiments,
+      linkedField = "dataset"
+    )
+
+    // don't need to use files apart from storing them, so we don't assign an output here
+    extractLinkedEntities(
+      entityToExtract = EncodeEntity.File,
+      matchingField = "@id",
+      linkingEntities = fc_experiments,
       linkedField = "dataset"
     )
 

--- a/src/test/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineSpec.scala
+++ b/src/test/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineSpec.scala
@@ -1,0 +1,62 @@
+package org.broadinstitute.monster.encode.extraction
+
+import io.circe.literal._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ExtractionPipelineSpec extends AnyFlatSpec with Matchers {
+  behavior of "ExtractionPipeline"
+
+  val fcExample =
+    json"""{
+        "@id": "/replicates/d80982c0-ae21-4e83-b3c9-fc7ec356c435/",
+        "@type": [
+          "Replicate",
+          "Item"
+        ],
+        "aliases": [
+          "tim-reddy:ggr-starrseq-input-rep11-rep"
+        ],
+        "biological_replicate_number": 11,
+        "date_created": "2019-11-07T21:22:51.002163+00:00",
+        "experiment": "/functional-characterization-experiments/ENCSR652MCH/",
+        "libraries": [
+           "ed595bdb-bab5-4b3b-acbf-221a131f4b4c"
+        ],
+        "library": "/libraries/ENCLB079TYN/",
+        "schema_version": "9",
+        "status": "released",
+        "submitted_by": "/users/a37a6376-c5a2-4fe0-b1af-7f078eb997c9/",
+        "technical_replicate_number": 1,
+        "uuid": "d80982c0-ae21-4e83-b3c9-fc7ec356c435"
+        }"""
+
+  val expExample =
+    json"""{
+      "@id": "/replicates/3c996486-0a1b-466c-be00-6d7cd7a89581/",
+      "@type": [
+        "Replicate",
+        "Item"
+      ],
+      "aliases": [],
+      "biological_replicate_number": 1,
+      "date_created": "2019-11-21T23:02:31.637903+00:00",
+      "experiment": "/experiments/ENCSR426KOP/",
+      "libraries": [
+        "f88d7865-b60b-418f-a0b1-0bf3fabc3c95"
+      ],
+      "library": "/libraries/ENCLB355PRN/",
+      "schema_version": "9",
+      "status": "released",
+      "submitted_by": "/users/bc5b62f7-ce28-4a1e-b6b3-81c9c5a86d7a/",
+      "technical_replicate_number": 1,
+      "uuid": "3c996486-0a1b-466c-be00-6d7cd7a89581"
+       }"""
+
+  it should "Distinguish between normal experiments and functional-characterization-experiments" in {
+    //functional-characterization-experiments case
+    ExtractionPipeline.isFunctionalCharacterizationReplicate(fcExample.asObject.get) shouldBe true
+    //normal experiments case
+    ExtractionPipeline.isFunctionalCharacterizationReplicate(expExample.asObject.get) shouldBe false
+  }
+}


### PR DESCRIPTION
Adding a new object to the EncodeEntity collection to add FunctionalCharacterizationExperiment. This dataset was previously assumed to be included under the "type=Experiment" query.
Also added code to the ExtractionPipeline script to store a new parent entity FunctionalCharacterizationExperiment and also added code to ensure we're pulling file data from that set of experiments.