### PR TITLE
Extend encode extraction to include targets

### DIFF
--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeEntity.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeEntity.scala
@@ -23,6 +23,8 @@ object EncodeEntity extends Enum[EncodeEntity] {
 
   case object Replicate extends EncodeEntity
 
+  case object Target extends EncodeEntity
+
   case object Audit extends EncodeEntity
 
   override def values: immutable.IndexedSeq[EncodeEntity] = findValues

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -43,11 +43,11 @@ object ExtractionPipeline {
       * Generic helper method for extracting linked entities and saving them.
       *
       * @param entityToExtract the entity which should be extracted
-      * @param matchingField name of the field to use as an identifier for the entityToExtract
-      *                      (should match the id that's used in the linkedField)
+      * @param matchingField name of the linkingEntity field which matches the value of the given "linkedField"
       * @param linkingEntities the parent entity (which references a set of encodeEntities)
       *                        from which ID extraction will be based
-      * @param linkedField name of the entityToExtract field which references the linkingEntities (default is @id)
+      * @param linkedField name of the entityToExtract field which matches the value of the given "matchingField"
+      *                    (default is @id)
       * @return the extracted linked entities
       */
     def extractLinkedEntities(
@@ -114,6 +114,13 @@ object ExtractionPipeline {
       matchingField = "@id",
       linkingEntities = experiments,
       linkedField = "dataset"
+    )
+
+    // don't need to use targets apart from storing them, so we don't assign an output here
+    extractLinkedEntities(
+      entityToExtract = EncodeEntity.Target,
+      matchingField = "target",
+      linkingEntities = experiments
     )
 
     pipelineContext.run()


### PR DESCRIPTION
Added Targets to the encode extraction and tried to improve some comments for the `extractLinkedEntities` function. 

The original [ticket description](https://broadinstitute.atlassian.net/browse/DSPDC-766) had suggested that we pull Antibody entities from the Replicates, and then pull Targets from the Antibodies. Raaid and I talked about this offline and weren't able to find anything that links Antibodies to Replicates (unless anyone knows otherwise) so we decided to change our approach. 

The new plan is to pull Targets from Experiments, and then pull Antibodies from Targets (the second part will be done in another ticket). 