### PR TITLE
QH DSPDC-772 Add logging to ENCODE extraction workflow

### DIFF
--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeExtractions.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeExtractions.scala
@@ -78,6 +78,7 @@ object EncodeExtractions {
           s"$key=$value"
       }
       val allParams = s"type=${encodeEntity.entryName}" :: baseParams ::: paramStrings
+
       get(client, allParams)
     }
 

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeExtractions.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeExtractions.scala
@@ -52,6 +52,8 @@ object EncodeExtractions {
     }
   }
 
+  val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+
   /** HTTP client to use for querying ENCODE APIs. */
   val client = new OkHttpClient()
 
@@ -76,7 +78,6 @@ object EncodeExtractions {
           s"$key=$value"
       }
       val allParams = s"type=${encodeEntity.entryName}" :: baseParams ::: paramStrings
-
       get(client, allParams)
     }
 
@@ -96,6 +97,7 @@ object EncodeExtractions {
         .get
         .build
 
+      logger.debug(s"New API Query: [$request]")
       client
         .newCall(request)
         .enqueue(new Callback {

--- a/src/test/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineSpec.scala
+++ b/src/test/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineSpec.scala
@@ -51,7 +51,7 @@ class ExtractionPipelineSpec extends AnyFlatSpec with Matchers {
       "submitted_by": "/users/bc5b62f7-ce28-4a1e-b6b3-81c9c5a86d7a/",
       "technical_replicate_number": 1,
       "uuid": "3c996486-0a1b-466c-be00-6d7cd7a89581"
-       }"""
+      }"""
 
   it should "Distinguish between normal experiments and functional-characterization-experiments" in {
     //functional-characterization-experiments case


### PR DESCRIPTION
Adding a logger to EncodeExtractions and invoking once a new API request has been built - right before it is called. encode-ingest/src/main/resources/logback.xml is already configured to print DEBUG level logs to the console.

Here's an example of what the console printout looks like:
`[info] 15:09:34.195 [direct-runner-worker] DEBUG o.b.m.e.e.EncodeExtractions$ - New API Query: [Request{method=GET, url=https://www.encodeproject.org/search/?type=Biosample&frame=object&status=released&limit=all&format=json&organism.name=human, tag=null}]

[info] 15:09:51.537 [direct-runner-worker] DEBUG o.b.m.e.e.EncodeExtractions$ - New API Query: [Request{method=GET, url=https://www.encodeproject.org/search/?type=Donor&frame=object&status=released&limit=all&format=json&@id=/human-donors/ENCDO237AAA/&@id=/human-donors/ENCDO821XRR/&@id=/human-donors/ENCDO000ABC/&@id=/human-donors/ENCDO605ZCF/&@id=/human-donors/ENCDO126IGB/&@id=/human-donors/ENCDO920LST/&@id=/human-donors/ENCDO592CQV/&@id=/human-donors/ENCDO754GEB/&@id=/human-donors/ENCDO749NWS/&@id=/human-donors/ENCDO017FQX/&@id=/human-donors/ENCDO171HMD/&@id=/human-donors/ENCDO859GXV/&@id=/human-donors/ENCDO137AAA/&@id=/human-donors/ENCDO072LQF/&@id=/human-donors/ENCDO250AAA/&@id=/human-donors/ENCDO009AAA/&@id=/human-donors/ENCDO265AAA/&@id=/human-donors/ENCDO860QGG/&@id=/human-donors/ENCDO839WKQ/&@id=/human-donors/ENCDO000ADG/&@id=/human-donors/ENCDO222AAA/&@id=/human-donors/ENCDO697GBW/&@id=/human-donors/ENCDO122AAA/&@id=/human-donors/ENCDO840PTG/&@id=/human-donors/ENCDO870OBN/&@id=/human-donors/ENCDO685SWK/&@id=/human-donors/ENCDO568LPD/&@id=/human-donors/ENCDO350AAA/&@id=/human-donors/ENCDO844VGJ/&@id=/human-donors/ENCDO291NZF/&@id=/human-donors/ENCDO036AAA/&@id=/human-donors/ENCDO338AAA/&@id=/human-donors/ENCDO000ABD/&@id=/human-donors/ENCDO634FAB/&@id=/human-donors/ENCDO000ABF/&@id=/human-donors/ENCDO000ADI/&@id=/human-donors/ENCDO000ADH/&@id=/human-donors/ENCDO165PKL/&@id=/human-donors/ENCDO064AAA/&@id=/human-donors/ENCDO058TGV/&@id=/human-donors/ENCDO021AAA/&@id=/human-donors/ENCDO226BUZ/&@id=/human-donors/ENCDO000ABE/&@id=/human-donors/ENCDO323AAA/&@id=/human-donors/ENCDO828APO/&@id=/human-donors/ENCDO000ADJ/&@id=/human-donors/ENCDO109AAA/&@id=/human-donors/ENCDO733WDT/&@id=/human-donors/ENCDO000ADK/&@id=/human-donors/ENCDO820BXZ/&@id=/human-donors/ENCDO978TAT/&@id=/human-donors/ENCDO000ABG/&@id=/human-donors/ENCDO494DYG/&@id=/human-donors/ENCDO085ZKK/&@id=/human-donors/ENCDO931OZF/&@id=/human-donors/ENCDO544NAV/&@id=/human-donors/ENCDO123AAA/&@id=/human-donors/ENCDO819ZMM/&@id=/human-donors/ENCDO607LOS/&@id=/human-donors/ENCDO806ILG/&@id=/human-donors/ENCDO050AAA/&@id=/human-donors/ENCDO351AAA/&@id=/human-donors/ENCDO119ASK/&@id=/human-donors/ENCDO460ZVO/&@id=/human-donors/ENCDO315JDK/&@id=/human-donors/ENCDO431WFV/&@id=/human-donors/ENCDO000ADL/&@id=/human-donors/ENCDO293DRY/&@id=/human-donors/ENCDO180AAA/&@id=/human-donors/ENCDO191CQJ/&@id=/human-donors/ENCDO324AAA/&@id=/human-donors/ENCDO138AAA/&@id=/human-donors/ENCDO223AAA/&@id=/human-donors/ENCDO000ABH/&@id=/human-donors/ENCDO000ABK/&@id=/human-donors/ENCDO150AAA/&@id=/human-donors/ENCDO037AAA/&@id=/human-donors/ENCDO445VEE/&@id=/human-donors/ENCDO022AAA/&@id=/human-donors/ENCDO238AAA/&@id=/human-donors/ENCDO999QDI/, tag=null}]

[info] 15:10:03.445 [direct-runner-worker] DEBUG o.b.m.e.e.EncodeExtractions$ - New API Query: [Request{method=GET, url=https://www.encodeproject.org/search/?type=Library&frame=object&status=released&limit=all&format=json&biosample.accession=ENCBS210WPX&biosample.accession=ENCBS076RNA&biosample.accession=ENCBS503AAA&biosample.accession=ENCBS555IZN&biosample.accession=ENCBS361VFY&biosample.accession=ENCBS316AAA&biosample.accession=ENCBS721SRV&biosample.accession=ENCBS669IAZ&biosample.accession=ENCBS064RNA&biosample.accession=ENCBS954ULS&biosample.accession=ENCBS928AKR&biosample.accession=ENCBS268PXW&biosample.accession=ENCBS287AAA&biosample.accession=ENCBS430MWW&biosample.accession=ENCBS890POO&biosample.accession=ENCBS118UBO&biosample.accession=ENCBS222WNL&biosample.accession=ENCBS192TUB&biosample.accession=ENCBS277GLZ&biosample.accession=ENCBS449AIA&biosample.accession=ENCBS165NPS&biosample.accession=ENCBS862GKZ&biosample.accession=ENCBS153NPL&biosample.accession=ENCBS234WKE&biosample.accession=ENCBS721SKH&biosample.accession=ENCBS524YUI&biosample.accession=ENCBS708BLT&biosample.accession=ENCBS987KVB&biosample.accession=ENCBS167CXV&biosample.accession=ENCBS316RCQ&biosample.accession=ENCBS902LKX&biosample.accession=ENCBS362YKU&biosample.accession=ENCBS505GEX&biosample.accession=ENCBS099OIO&biosample.accession=ENCBS148BFZ&biosample.accession=ENCBS606CKR&biosample.accession=ENCBS299AAA&biosample.accession=ENCBS575NGC&biosample.accession=ENCBS349YRA&biosample.accession=ENCBS643TDG&biosample.accession=ENCBS113ENC&biosample.accession=ENCBS578FNZ&biosample.accession=ENCBS992XAC&biosample.accession=ENCBS374YBC&biosample.accession=ENCBS672OLU&biosample.accession=ENCBS358PHP&biosample.accession=ENCBS515RAW&biosample.accession=ENCBS796YDW&biosample.accession=ENCBS746EOD&biosample.accession=ENCBS416JZI&biosample.accession=ENCBS006KAW&biosample.accession=ENCBS120GNH&biosample.accession=ENCBS051OXV&biosample.accession=ENCBS313YTO&biosample.accession=ENCBS649DTO&biosample.accession=ENCBS733SDO&biosample.accession=ENCBS269SYD&biosample.accession=ENCBS093MVN&biosample.accession=ENCBS579ZTI&biosample.accession=ENCBS765FVI&biosample.accession=ENCBS509STK&biosample.accession=ENCBS697QYY&biosample.accession=ENCBS450RLH&biosample.accession=ENCBS662URL&biosample.accession=ENCBS015AWQ&biosample.accession=ENCBS770SDC&biosample.accession=ENCBS269BVG&biosample.accession=ENCBS515ABR&biosample.accession=ENCBS619FIX&biosample.accession=ENCBS208CBB&biosample.accession=ENCBS386HKI&biosample.accession=ENCBS777WTV&biosample.accession=ENCBS078XUR&biosample.accession=ENCBS307JGV&biosample.accession=ENCBS475UJY&biosample.accession=ENCBS859AAA&biosample.accession=ENCBS931GIA&biosample.accession=ENCBS723HLT&biosample.accession=ENCBS636RQT&biosample.accession=ENCBS631TEJ&biosample.accession=ENCBS817CIX&biosample.accession=ENCBS488GLI&biosample.accession=ENCBS547VCK&biosample.accession=ENCBS449AKC&biosample.accession=ENCBS903OGK&biosample.accession=ENCBS415GVR&biosample.accession=ENCBS088RNA&biosample.accession=ENCBS675GRD&biosample.accession=ENCBS670ZEX&biosample.accession=ENCBS509SVT&biosample.accession=ENCBS636AQY&biosample.accession=ENCBS948WDK&biosample.accession=ENCBS580ZQI&biosample.accession=ENCBS047FHC&biosample.accession=ENCBS259ZOP&biosample.accession=ENCBS379WNC&biosample.accession=ENCBS083TEY&biosample.accession=ENCBS860AAA&biosample.accession=ENCBS126ZAB&biosample.accession=ENCBS967GAK, tag=null}]`