### PR TITLE
QH DSPDC-765 - Update encode-ingest to use new scio-utils library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ lazy val `encode-ingest` = project
     ),
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % scalatestVersion,
-      "io.circe" %% "circe-literal" % MonsterJadeDatasetPlugin.CirceVersion,
     ).map(_ % Test),
     scioReleaseBucketName := "TODO",
     scioSnapshotBucketName := "TODO"

--- a/build.sbt
+++ b/build.sbt
@@ -1,28 +1,18 @@
-import org.broadinstitute.monster.sbt.model.JadeIdentifier
-
 val enumeratumVersion = "1.5.13"
-val logbackVersion = "1.2.3"
-val scioVersion = "0.8.0"
 
 val scalatestVersion = "3.1.0"
 
 lazy val `encode-ingest` = project
   .in(file("."))
-  .enablePlugins(MonsterJadeDatasetPlugin)
+  .enablePlugins(MonsterScioPipelinePlugin)
   .settings(
-    jadeDatasetName := JadeIdentifier
-      .fromString("broad_dsp_encode")
-      .fold(sys.error, identity),
-    jadeDatasetDescription := "Mirror of the ENCODE project, maintained by Broad's Data Sciences Platform",
-    jadeTablePackage := "org.broadinstitute.monster.encode.jadeschema.table",
-    jadeStructPackage := "org.broadinstitute.monster.encode.jadeschema.struct",
     libraryDependencies ++= Seq(
       "com.beachape" %% "enumeratum" % enumeratumVersion,
-      "ch.qos.logback" % "logback-classic" % logbackVersion,
-      "com.spotify" %% "scio-extra" % scioVersion,
     ),
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % scalatestVersion,
       "io.circe" %% "circe-literal" % MonsterJadeDatasetPlugin.CirceVersion,
-    ).map(_ % Test)
+    ).map(_ % Test),
+    scioReleaseBucketName := "TODO",
+    scioSnapshotBucketName := "TODO"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,6 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-jade" % "0.6.0")
+addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-jade" % "0.7.0")
+
+addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-scio" % "0.7.0")

--- a/src/test/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineSpec.scala
+++ b/src/test/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineSpec.scala
@@ -55,6 +55,7 @@ class ExtractionPipelineSpec extends AnyFlatSpec with Matchers {
       "technical_replicate_number": 1,
       "uuid": "3c996486-0a1b-466c-be00-6d7cd7a89581"
       }"""
+    )
 
   it should "Distinguish between normal experiments and functional-characterization-experiments" in {
     //functional-characterization-experiments case

--- a/src/test/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineSpec.scala
+++ b/src/test/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineSpec.scala
@@ -1,14 +1,15 @@
 package org.broadinstitute.monster.encode.extraction
 
-import io.circe.literal._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.broadinstitute.monster.common.msg.JsonParser
 
 class ExtractionPipelineSpec extends AnyFlatSpec with Matchers {
   behavior of "ExtractionPipeline"
 
   val fcExample =
-    json"""{
+    JsonParser.parseEncodedJson(
+      """{
         "@id": "/replicates/d80982c0-ae21-4e83-b3c9-fc7ec356c435/",
         "@type": [
           "Replicate",
@@ -30,9 +31,11 @@ class ExtractionPipelineSpec extends AnyFlatSpec with Matchers {
         "technical_replicate_number": 1,
         "uuid": "d80982c0-ae21-4e83-b3c9-fc7ec356c435"
         }"""
+    )
 
   val expExample =
-    json"""{
+    JsonParser.parseEncodedJson(
+      """{
       "@id": "/replicates/3c996486-0a1b-466c-be00-6d7cd7a89581/",
       "@type": [
         "Replicate",
@@ -51,12 +54,13 @@ class ExtractionPipelineSpec extends AnyFlatSpec with Matchers {
       "submitted_by": "/users/bc5b62f7-ce28-4a1e-b6b3-81c9c5a86d7a/",
       "technical_replicate_number": 1,
       "uuid": "3c996486-0a1b-466c-be00-6d7cd7a89581"
-       }"""
+      }"""
+    )
 
   it should "Distinguish between normal experiments and functional-characterization-experiments" in {
     //functional-characterization-experiments case
-    ExtractionPipeline.isFunctionalCharacterizationReplicate(fcExample.asObject.get) shouldBe true
+    ExtractionPipeline.isFunctionalCharacterizationReplicate(fcExample) shouldBe true
     //normal experiments case
-    ExtractionPipeline.isFunctionalCharacterizationReplicate(expExample.asObject.get) shouldBe false
+    ExtractionPipeline.isFunctionalCharacterizationReplicate(expExample) shouldBe false
   }
 }


### PR DESCRIPTION
Added the sbt-plugins-scio plugin + bumped up the Jade plugin to match (0.7.0).
Replaced MonsterJadeDatasetPlugin with MonsterScioPipelinePlugin.
Updated EncodeExtractions and ExtractionPipeline to replace usages of JsonObject (io.circe) with Msg (upack). This required some rework - using the UpackMsgCoder, replacing the SCollection[JsonObject] with SCollection[Msg], and replacing `extract` calls with `read` or `tryRead` and instance of `saveAsJsonFile` with `writeJsonLists`.
For the unit tests, I used a JsonParser to read the mocked JsonObjects and pass them to the tested function.