### PR TITLE
QH - DSPDC-766 - Update ENCODE extraction pipeline to pull Target objects

### DIFF
--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeEntity.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/EncodeEntity.scala
@@ -27,6 +27,8 @@ object EncodeEntity extends Enum[EncodeEntity] {
 
   case object AntibodyLot extends EncodeEntity
 
+  case object Target extends EncodeEntity
+
   case object Audit extends EncodeEntity
 
   override def values: immutable.IndexedSeq[EncodeEntity] = findValues

--- a/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -119,17 +119,23 @@ object ExtractionPipeline {
       linkedField = "library.accession"
     )
 
+    val antibodies = extractLinkedEntities(
+      entityToExtract = EncodeEntity.AntibodyLot,
+      matchingField = "antibody",
+      linkingEntities = replicates
+    )
+
+    extractLinkedEntities(
+      entityToExtract = EncodeEntity.Target,
+      matchingField = "targets",
+      linkingEntities = antibodies
+    )
+
     // partition the replicates stream into two separate SCollection[Msg]
     //passing in a new function to check to see if the experiment type
     val (fcReplicate, expReplicate) = replicates.partition { replicate =>
       isFunctionalCharacterizationReplicate(replicate)
     }
-
-    extractLinkedEntities(
-      entityToExtract = EncodeEntity.AntibodyLot,
-      matchingField = "antibody",
-      linkingEntities = replicates
-    )
 
     val experiments = extractLinkedEntities(
       entityToExtract = EncodeEntity.Experiment,


### PR DESCRIPTION
Added a new EncodeEntity for Target data.
Updated the ExtractionPipeline file to store the AntibodyLot entity SCollection[Msg] to a constant "antibodies" and then pull target data out.
Rearranged the order slightly to group all of the experiment partitioning code together in the same block.