### PR TITLE
QH - DSPDC-763 - Parameterized the ENCODE extraction workflow + Added integration test

### DIFF
--- a/extraction/src/it/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineIntegrationSpec.scala
+++ b/extraction/src/it/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineIntegrationSpec.scala
@@ -24,61 +24,56 @@ class ExtractionPipelineIntegrationSpec extends PipelineBuilderSpec[Args] {
   override val builder = ExtractionPipeline.pipelineBuilder
 
   // Paths for entity files downloaded
-  val AnalysisStepPath = (outputDir.pathAsString + "/AnalysisStep")
-  val AnalysisStepRunPath = (outputDir.pathAsString + "/AnalysisStepRun")
-  val AnalysisStepVersionPath = (outputDir.pathAsString + "/AnalysisStepVersion")
-  val AntibodyLotPath = (outputDir.pathAsString + "/AntibodyLot")
-  val BiosamplePath = (outputDir.pathAsString + "/Biosample")
-  val DonorPath = (outputDir.pathAsString + "/Donor")
-  val ExperimentPath = (outputDir.pathAsString + "/Experiment")
-  val FilePath = (outputDir.pathAsString + "/File")
-  val FunctionalCharacterizationExperimentPath = (outputDir.pathAsString + "/FunctionalCharacterizationExperiment")
-  val LibraryPath = (outputDir.pathAsString + "/Library")
-  val ReplicatePath = (outputDir.pathAsString + "/Replicate")
-  val TargetPath = (outputDir.pathAsString + "/Target")
+  val analysisStepPath = (outputDir.pathAsString + "/AnalysisStep")
+  val analysisStepRunPath = (outputDir.pathAsString + "/AnalysisStepRun")
+  val analysisStepVersionPath = (outputDir.pathAsString + "/AnalysisStepVersion")
+  val antibodyLotPath = (outputDir.pathAsString + "/AntibodyLot")
+  val biosamplePath = (outputDir.pathAsString + "/Biosample")
+  val donorPath = (outputDir.pathAsString + "/Donor")
+  val experimentPath = (outputDir.pathAsString + "/Experiment")
+  val filePath = (outputDir.pathAsString + "/File")
+  val functionalCharacterizationExperimentPath = (outputDir.pathAsString + "/FunctionalCharacterizationExperiment")
+  val libraryPath = (outputDir.pathAsString + "/Library")
+  val replicatePath = (outputDir.pathAsString + "/Replicate")
+  val targetPath = (outputDir.pathAsString + "/Target")
 
   /// VERIFY DOWNLOADS
   behavior of "ExtractionPipeline"
 
-  it should "successfully download results from the from Encode API" in {
-    outputDir.nonEmpty should be(true)
-    println("outputDir has contents...")
-  }
   it should "successfully download AnalysisStep files" in {
-    AnalysisStepPath.nonEmpty should be(true)
-    println("/AnalysisStep has contents...")
+    analysisStepPath.nonEmpty should be(true)
   }
   it should "successfully download AnalysisStepRun files" in {
-    AnalysisStepRunPath.nonEmpty should be(true)
+    analysisStepRunPath.nonEmpty should be(true)
   }
   it should "successfully download AnalysisStepVersion files" in {
-    AnalysisStepVersionPath.nonEmpty should be(true)
+    analysisStepVersionPath.nonEmpty should be(true)
   }
   it should "successfully download AntibodyLot files" in {
-    AntibodyLotPath.nonEmpty should be(true)
+    antibodyLotPath.nonEmpty should be(true)
   }
   it should "successfully download Biosample files" in {
-    BiosamplePath.nonEmpty should be(true)
+    biosamplePath.nonEmpty should be(true)
   }
   it should "successfully download Donor files" in {
-    DonorPath.nonEmpty should be(true)
+    donorPath.nonEmpty should be(true)
   }
   it should "successfully download Experiment files" in {
-    ExperimentPath.nonEmpty should be(true)
+    experimentPath.nonEmpty should be(true)
   }
   it should "successfully download File files" in {
-    FilePath.nonEmpty should be(true)
+    filePath.nonEmpty should be(true)
   }
   it should "successfully download FunctionalCharacterizationExperiment files" in {
-    FunctionalCharacterizationExperimentPath.nonEmpty should be(true)
+    functionalCharacterizationExperimentPath.nonEmpty should be(true)
   }
   it should "successfully download Library files" in {
-    LibraryPath.nonEmpty should be(true)
+    libraryPath.nonEmpty should be(true)
   }
   it should "successfully download Replicate files" in {
-    ReplicatePath.nonEmpty should be(true)
+    replicatePath.nonEmpty should be(true)
   }
   it should "successfully download Target files" in {
-    TargetPath.nonEmpty should be(true)
+    targetPath.nonEmpty should be(true)
   }
 }

--- a/extraction/src/it/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineIntegrationSpec.scala
+++ b/extraction/src/it/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineIntegrationSpec.scala
@@ -1,0 +1,84 @@
+package org.broadinstitute.monster.encode.extraction
+
+import better.files.File
+import org.broadinstitute.monster.common.PipelineBuilderSpec
+
+class ExtractionPipelineIntegrationSpec extends PipelineBuilderSpec[Args] {
+  val outputDir = File.newTemporaryDirectory()
+  override def afterAll(): Unit = outputDir.delete()
+
+  val testBatchSize: Long = 100
+
+  val allParams: List[(String, String)] = {
+    List(
+      // Default Human Params
+      "organism.name" -> "human",
+      // Human Test Sample
+      "accession" -> "ENCBS488IUR"
+    )
+  }
+
+  /// KICK OFF EXTRACTION
+  override val testArgs =
+    Args(outputDir.pathAsString, testBatchSize, allParams)
+  override val builder = ExtractionPipeline.pipelineBuilder
+
+  // Paths for entity files downloaded
+  val AnalysisStepPath = (outputDir.pathAsString + "/AnalysisStep")
+  val AnalysisStepRunPath = (outputDir.pathAsString + "/AnalysisStepRun")
+  val AnalysisStepVersionPath = (outputDir.pathAsString + "/AnalysisStepVersion")
+  val AntibodyLotPath = (outputDir.pathAsString + "/AntibodyLot")
+  val BiosamplePath = (outputDir.pathAsString + "/Biosample")
+  val DonorPath = (outputDir.pathAsString + "/Donor")
+  val ExperimentPath = (outputDir.pathAsString + "/Experiment")
+  val FilePath = (outputDir.pathAsString + "/File")
+  val FunctionalCharacterizationExperimentPath = (outputDir.pathAsString + "/FunctionalCharacterizationExperiment")
+  val LibraryPath = (outputDir.pathAsString + "/Library")
+  val ReplicatePath = (outputDir.pathAsString + "/Replicate")
+  val TargetPath = (outputDir.pathAsString + "/Target")
+
+  /// VERIFY DOWNLOADS
+  behavior of "ExtractionPipeline"
+
+  it should "successfully download results from the from Encode API" in {
+    outputDir.nonEmpty should be(true)
+    println("outputDir has contents...")
+  }
+  it should "successfully download AnalysisStep files" in {
+    AnalysisStepPath.nonEmpty should be(true)
+    println("/AnalysisStep has contents...")
+  }
+  it should "successfully download AnalysisStepRun files" in {
+    AnalysisStepRunPath.nonEmpty should be(true)
+  }
+  it should "successfully download AnalysisStepVersion files" in {
+    AnalysisStepVersionPath.nonEmpty should be(true)
+  }
+  it should "successfully download AntibodyLot files" in {
+    AntibodyLotPath.nonEmpty should be(true)
+  }
+  it should "successfully download Biosample files" in {
+    BiosamplePath.nonEmpty should be(true)
+  }
+  it should "successfully download Donor files" in {
+    DonorPath.nonEmpty should be(true)
+  }
+  it should "successfully download Experiment files" in {
+    ExperimentPath.nonEmpty should be(true)
+  }
+  it should "successfully download File files" in {
+    FilePath.nonEmpty should be(true)
+  }
+  it should "successfully download FunctionalCharacterizationExperiment files" in {
+    FunctionalCharacterizationExperimentPath.nonEmpty should be(true)
+  }
+  it should "successfully download Library files" in {
+    LibraryPath.nonEmpty should be(true)
+  }
+  it should "successfully download Replicate files" in {
+    ReplicatePath.nonEmpty should be(true)
+  }
+  it should "successfully download Target files" in {
+    TargetPath.nonEmpty should be(true)
+  }
+}

--- a/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/Args.scala
+++ b/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/Args.scala
@@ -31,7 +31,7 @@ case class Args(
 
 object Args {
 
-  implicit val customArgParser: ArgParser[(String, String)] =
+  implicit val tupleParser: ArgParser[(String, String)] =
     SimpleArgParser.from("key=value") { s =>
       val i = s.indexOf("=")
       if (i == -1) {

--- a/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/Args.scala
+++ b/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/Args.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.monster.encode.extraction
 
 import caseapp.{AppName, AppVersion, HelpMessage, ProgName}
+import caseapp.core.Error.MalformedValue
+import caseapp.core.argparser.{ArgParser, SimpleArgParser}
 import org.broadinstitute.monster.EncodeExtractionBuildInfo
 
 @AppName("ENCODE Extraction Pipeline")
@@ -20,5 +22,22 @@ case class Args(
   @HelpMessage(
     "Batch size that defines the number of elements in a batch when making certain API calls"
   )
-  batchSize: Long
+  batchSize: Long,
+  @HelpMessage(
+    "Initial query to target a specific entry-point to the pipeline."
+  )
+  initialQuery: List[(String, String)] = List("organism.name" -> "human")
 )
+
+object Args {
+
+  implicit val customArgParser: ArgParser[(String, String)] =
+    SimpleArgParser.from("key=value") { s =>
+      val i = s.indexOf("=")
+      if (i == -1) {
+        Left(MalformedValue("key=value", "Missing '=' delimiter"))
+      } else {
+        Right(s.take(i) -> s.drop(i + 1))
+      }
+    }
+}

--- a/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.monster.encode.extraction
 
-import Args.customArgParser
+import Args.tupleParser
 import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
 
 /** Entry-point for the Encode pipeline's Docker image. */

--- a/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
+++ b/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipeline.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.monster.encode.extraction
 
+import Args.customArgParser
 import org.broadinstitute.monster.common.{PipelineBuilder, ScioApp}
 
 /** Entry-point for the Encode pipeline's Docker image. */

--- a/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineBuilder.scala
+++ b/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineBuilder.scala
@@ -67,7 +67,7 @@ class ExtractionPipelineBuilder(getClient: () => EncodeClient)
 
     // biosamples are the first one and follow a different pattern, so we don't use the generic method
     val biosamples = ctx
-      .parallelize(List({ args.initialQuery }))
+      .parallelize(List(args.initialQuery))
       .transform(s"Extract ${EncodeEntity.Biosample} data") { rawData =>
         val biosamples = getEntities(EncodeEntity.Biosample)(rawData)
         writeJsonLists(

--- a/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineBuilder.scala
+++ b/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineBuilder.scala
@@ -67,7 +67,7 @@ class ExtractionPipelineBuilder(getClient: () => EncodeClient)
 
     // biosamples are the first one and follow a different pattern, so we don't use the generic method
     val biosamples = ctx
-      .parallelize(List(List("organism.name" -> "human")))
+      .parallelize(List({ args.initialQuery }))
       .transform(s"Extract ${EncodeEntity.Biosample} data") { rawData =>
         val biosamples = getEntities(EncodeEntity.Biosample)(rawData)
         writeJsonLists(


### PR DESCRIPTION
The Encode extraction workflow can now take in query parameters.
This will allow us to pass more targeted entry-points to the pipeline during testing and also allow us to query for other organism types (currently hardcoded to pull human donor data).
I also added an integration test that just takes one biosample accession and makes sure that we downloaded some stuff to the temporary directories. Not sure how often biosamples change - it would be great to use a biosample we know will never change. Maybe Encode has some seed data for this purpose?