### PR TITLE
DSPDC-238 Fix some transformation bugs.

### DIFF
--- a/schema/src/main/jade-tables/biosample.table.json
+++ b/schema/src/main/jade-tables/biosample.table.json
@@ -53,7 +53,6 @@
     {
       "name": "donor_id",
       "datatype": "string",
-      "type": "required",
       "links": [
         {
           "table_name": "donor",

--- a/transformation/src/main/scala/org/broadinstitute/monster/encode/transformation/AntibodyTransformations.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/encode/transformation/AntibodyTransformations.scala
@@ -12,7 +12,7 @@ object AntibodyTransformations {
     import org.broadinstitute.monster.common.msg.MsgOps
 
     val targetNames = joinedTargets
-      .filter(_.read[String]("organism") == "/organisms/human/")
+      .filter(_.tryRead[String]("organism").contains("/organisms/human/"))
       .map(_.read[String]("label"))
       .toArray
       .sorted

--- a/transformation/src/main/scala/org/broadinstitute/monster/encode/transformation/BiosampleTransformations.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/encode/transformation/BiosampleTransformations.scala
@@ -44,7 +44,7 @@ object BiosampleTransformations {
       biosampleType = joinedType.map(_.read[String]("classification")),
       samplePreservationState = biosampleInput.tryRead[String]("preservation_method"),
       seeAlso = biosampleInput.tryRead[String]("url"),
-      donorId = CommonTransformations.transformId(biosampleInput.read[String]("donor")),
+      donorId = biosampleInput.tryRead[String]("donor").map(CommonTransformations.transformId),
       auditLabels = auditLabels,
       maxAuditFlag = auditLevel,
       award = biosampleInput.read[String]("award"),


### PR DESCRIPTION
I got the extract->transform loop running in dev (no notification yet). The first run [failed](https://console.cloud.google.com/dataflow/jobs/us-west1/2020-04-29_05_19_17-4123484396362716805?project=broad-dsp-monster-encode-dev), this should relax our assumptions about metadata structure enough for it to pass (or at least fail on other things).