### PR TITLE
QH - DSPDC-1028 - Bumping sbtPluginsVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import _root_.io.circe.Json
-import org.broadinstitute.monster.sbt.model.JadeIdentifier
 
 val enumeratumVersion = "1.5.15"
 val okhttpVersion = "4.4.1"
@@ -41,10 +40,6 @@ lazy val `encode-schema` = project
   .in(file("schema"))
   .enablePlugins(MonsterJadeDatasetPlugin)
   .settings(
-    jadeDatasetName := JadeIdentifier
-      .fromString("broad_dsp_encode")
-      .fold(sys.error, identity),
-    jadeDatasetDescription := "Mirror of ENCODE, maintained by Broad's Data Sciences Platform",
     jadeTablePackage := "org.broadinstitute.monster.encode.jadeschema.table",
     jadeStructPackage := "org.broadinstitute.monster.encode.jadeschema.struct"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-val sbtPluginsVersion = "0.20.0"
+val sbtPluginsVersion = "0.23.0"
 
 addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-jade" % sbtPluginsVersion)
 addSbtPlugin("org.broadinstitute.monster" % "sbt-plugins-scio" % sbtPluginsVersion)


### PR DESCRIPTION
Updating the sbtPluginsVersion to match the most recent monster-sbt-plugins release.
Updating build.sbt to reflect Raaid's downstream changes in DSPDC-1067.
Pipeline tests completed successfully.