### PR TITLE
DSPDC-1099 Add example input values for orchestration linting.

### DIFF
--- a/orchestration/example-values/no-version.yaml
+++ b/orchestration/example-values/no-version.yaml
@@ -1,0 +1,25 @@
+gcs:
+  bucketName: bucket
+serviceAccount:
+  k8sName: account
+  googleName: account@goog
+cron:
+  schedule: '@daily'
+dataflow:
+  project: project
+  tmpBucketName: buckety
+  subnetName: net
+  workerAccount: dataflow@goog
+  useFlexRS: true
+bigquery:
+  stagingData:
+    project: project
+    datasetPrefix: monster_staging_data
+    description: The coolest dataset
+    expiration: '1' # Gotta go fast
+  jadeData:
+    project: jade-data
+aws:
+  credentialsSecretName: shhhhh
+smokeTest:
+  enable: false

--- a/orchestration/example-values/pinned-version.yaml
+++ b/orchestration/example-values/pinned-version.yaml
@@ -1,0 +1,28 @@
+gcs:
+  bucketName: bucket
+serviceAccount:
+  k8sName: account
+  googleName: account@goog
+cron:
+  schedule: '@daily'
+dataflow:
+  project: project
+  tmpBucketName: buckety
+  subnetName: net
+  workerAccount: dataflow@goog
+  useFlexRS: true
+bigquery:
+  stagingData:
+    project: project
+    datasetPrefix: monster_staging_data
+    description: The coolest dataset
+    expiration: '1' # Gotta go fast
+  jadeData:
+    project: jade-data
+aws:
+  credentialsSecretName: shhhhh
+smokeTest:
+  enable: false
+argoTemplates:
+  diffBQTable:
+    schemaImageVersion: a-pinned-version

--- a/orchestration/example-values/smoke-test.yaml
+++ b/orchestration/example-values/smoke-test.yaml
@@ -1,0 +1,28 @@
+gcs:
+  bucketName: bucket
+serviceAccount:
+  k8sName: account
+  googleName: account@goog
+cron:
+  schedule: '@daily'
+dataflow:
+  project: project
+  tmpBucketName: buckety
+  subnetName: net
+  workerAccount: dataflow@goog
+  useFlexRS: true
+bigquery:
+  stagingData:
+    project: project
+    datasetPrefix: monster_staging_data
+    description: The coolest dataset
+    expiration: '1' # Gotta go fast
+  jadeData:
+    project: jade-data
+aws:
+  credentialsSecretName: shhhhh
+smokeTest:
+  enable: true
+  slackUrl:
+    secretName: shh
+    secretKey: erl


### PR DESCRIPTION
Values are fake, but the structure / types are real. The new version of `MonsterHelmPlugin` will detect these files on `test` and validate that each one produces valid YAML with `helm template`.