### PR TITLE
QH DSPDC-1055 + DSPDC-1056 - extending ENCODE orcehstration workflow to soft-delete AND ingest tablular data.

### DIFF
--- a/orchestration/templates/ingest-processed-data.yaml
+++ b/orchestration/templates/ingest-processed-data.yaml
@@ -19,6 +19,7 @@ spec:
       parallelism: 1
       dag:
         tasks:
+          # Create a dataset to store intermediate outputs of ETL jobs.
           {{- $datasetName := printf "%s_%s" .Values.bigquery.stagingData.datasetPrefix $gcsPrefix }}
           - name: create-dataset
             templateRef:
@@ -37,6 +38,7 @@ spec:
                   value: '{{ .expiration }}'
                 {{- end }}
 
+          # Loop over all tables, syncing state in Jade to match data staged in GCS.
           - name: process-tables
             dependencies: [create-dataset]
             withItems:
@@ -75,6 +77,8 @@ spec:
       dag:
         tasks:
           # Diff staged data against previously-ingested state.
+          {{- $newRowsPrefix := printf "%s/new-rows/%s" $gcsPrefix $tableName }}
+          {{- $oldIdsPrefix := printf "%s/old-ids/%s" $gcsPrefix $tableName }}
           - name: diff-table
             templateRef:
               name: {{ .Values.argoTemplates.diffBQTable.name }}
@@ -88,9 +92,9 @@ spec:
                 - name: input-prefix
                   value: '{{ printf "%s/processed/%s" $gcsPrefix $tableName }}'
                 - name: old-ids-output-prefix
-                  value: '{{ printf "%s/old-ids/%s" $gcsPrefix $tableName }}'
+                  value: '{{ $oldIdsPrefix }}'
                 - name: new-rows-output-prefix
-                  value: '{{ printf "%s/new-rows/%s" $gcsPrefix $tableName }}'
+                  value: '{{ $newRowsPrefix }}'
                 - name: staging-bq-project
                   value: '{{ .Values.bigquery.stagingData.project }}'
                 - name: staging-bq-dataset
@@ -101,3 +105,59 @@ spec:
                   value: '{{ .Values.bigquery.jadeData.dataset }}'
             {{- $shouldAppend := "{{tasks.diff-table.outputs.parameters.rows-to-append-count}} > 0" }}
             {{- $shouldDelete := "{{tasks.diff-table.outputs.parameters.ids-to-delete-count}} > 0" }}
+
+          # Soft-delete IDs of outdated rows.
+          - name: soft-delete-table
+            dependencies: [diff-table]
+            when: '{{ $shouldDelete }}'
+            templateRef:
+              name: {{ .Values.argoTemplates.softDeleteTable.name }}
+              template: main
+            arguments:
+              parameters:
+                - name: table-name
+                  value: '{{ $tableName }}'
+                - name: gcs-prefix
+                  value: '{{ $oldIdsPrefix }}'
+                - name: gcs-bucket
+                  value: '{{ .Values.gcs.bucketName }}'
+                {{- with .Values.repo }}
+                - name: url
+                  value: '{{ .url }}'
+                - name: dataset-id
+                  value: '{{ .datasetId }}'
+                - name: timeout
+                  value: '{{ .pollTimeout }}'
+                - name: sa-secret
+                  value: '{{ .accessKey.secretName }}'
+                - name: sa-secret-key
+                  value: '{{ .accessKey.secretKey }}'
+                {{- end }}
+
+          # Append rows with new data.
+          - name: ingest-table
+            dependencies: [diff-table, soft-delete-table]
+            when: '{{ $shouldAppend }}'
+            templateRef:
+              name:  {{ .Values.argoTemplates.ingestTable.name }}
+              template: main
+            arguments:
+              parameters:
+                - name: table-name
+                  value: '{{ $tableName }}'
+                - name: gcs-bucket
+                  value: '{{ .Values.gcs.bucketName }}'
+                - name: gcs-prefix
+                  value: '{{ $newRowsPrefix }}'
+                {{- with .Values.repo }}
+                - name: url
+                  value: '{{ .url }}'
+                - name: dataset-id
+                  value: '{{ .datasetId }}'
+                - name: timeout
+                  value: '{{ .pollTimeout }}'
+                - name: sa-secret
+                  value: '{{ .accessKey.secretName }}'
+                - name: sa-secret-key
+                  value: '{{ .accessKey.secretKey }}'
+                {{- end }}

--- a/orchestration/values.schema.json
+++ b/orchestration/values.schema.json
@@ -107,7 +107,25 @@
         }
       },
       "required": ["stagingData", "jadeData"]
+    },
+    "repo" : {
+      "type": "object",
+      "properties": {
+        "url": {"type":  "string"},
+        "datasetId": {"type": "string"},
+        "profileId": {"type": "string"},
+        "pollTimeout": {"type":  "integer"},
+        "accessKey": {
+          "type": "object",
+          "properties": {
+            "secretName": {"type": "string"},
+            "secretKey": {"type": "string"}
+          },
+          "required": ["secretName", "secretKey"]
+        }
+      },
+      "required": ["url", "datasetId", "profileId", "pollTimeout", "accessKey"]
     }
   },
-  "required": ["gcs", "serviceAccount", "cron", "dataflow", "volumes", "aws", "smokeTest"]
+  "required": ["gcs", "serviceAccount", "cron", "dataflow", "volumes", "aws", "smokeTest", "repo"]
 }

--- a/orchestration/values.yaml
+++ b/orchestration/values.yaml
@@ -32,8 +32,17 @@ argoTemplates:
   createBQDataset:
     create: true
     name: create-bq-dataset
+  softDeleteTable:
+    create: true
+    name: soft-delete-table
+  ingestTable:
+    create: true
+    name: ingest-table
 smokeTest:
   enable: false
 bigquery:
   jadeData:
     dataset: datarepo_broad_dsp_encode
+repo:
+  # 24 hours -> 86400 seconds
+  pollTimeout: 86400


### PR DESCRIPTION
Added soft-delete-table and ingest-table charts (pulled from clinvar-ingest logic.
Also added some comments, and added variables to store gcs prefixes.
Added softDeleteTable and ingestTable charts to templates in values file.
Added repo object to the values.schema.json file in order to provide all paramaters needed by new soft-delete and ingest-table steps.