### PR TITLE
Pull in latest ingest-utils

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 75%
-        threshold: 5%
-

--- a/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineBuilder.scala
+++ b/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineBuilder.scala
@@ -216,7 +216,7 @@ class ExtractionPipelineBuilder(getClient: () => EncodeClient)
     writeJsonListsGeneric(
       files,
       EncodeEntity.File.entryName,
-      s"${args.outputDir}/${EncodeEntity.File.entrydName}"
+      s"${args.outputDir}/${EncodeEntity.File.entryName}"
     )
 
     val analysisStepRuns = extractLinkedEntities(

--- a/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineBuilder.scala
+++ b/extraction/src/main/scala/org/broadinstitute/monster/encode/extraction/ExtractionPipelineBuilder.scala
@@ -6,7 +6,7 @@ import com.spotify.scio.transforms.ScalaAsyncLookupDoFn
 import com.spotify.scio.values.SCollection
 import org.apache.beam.sdk.transforms.ParDo
 import org.broadinstitute.monster.common.PipelineBuilder
-import org.broadinstitute.monster.common.StorageIO.writeJsonLists
+import org.broadinstitute.monster.common.StorageIO.writeJsonListsGeneric
 import org.broadinstitute.monster.common.msg.{MsgOps, UpackMsgCoder}
 import org.broadinstitute.monster.encode.EncodeEntity
 import upack._
@@ -80,7 +80,7 @@ class ExtractionPipelineBuilder(getClient: () => EncodeClient)
     ): SCollection[Msg] = {
       val out = getEntities(encodeEntity, queryBatches.map(_ -> negativeFilters))
         .distinctBy(_.read[String]("@id"))
-      writeJsonLists(
+      writeJsonListsGeneric(
         out,
         encodeEntity.entryName,
         s"${args.outputDir}/${encodeEntity.entryName}"
@@ -213,10 +213,10 @@ class ExtractionPipelineBuilder(getClient: () => EncodeClient)
       getEntities(EncodeEntity.File, queryBatches)
     }
 
-    writeJsonLists(
+    writeJsonListsGeneric(
       files,
       EncodeEntity.File.entryName,
-      s"${args.outputDir}/${EncodeEntity.File.entryName}"
+      s"${args.outputDir}/${EncodeEntity.File.entrydName}"
     )
 
     val analysisStepRuns = extractLinkedEntities(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.0.1")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.6")

--- a/transformation/src/main/scala/org/broadinstitute/monster/encode/transformation/FileTransformations.scala
+++ b/transformation/src/main/scala/org/broadinstitute/monster/encode/transformation/FileTransformations.scala
@@ -37,7 +37,8 @@ object FileTransformations {
     val Seq(sequence, alignment, other) = rawStream
       .withName("Split raw files by category")
       .partition(
-        3, {
+        3,
+        {
           case (rawFile, _) =>
             val category = rawFile.read[String]("output_category")
             if (category == SequencingCategory) 0


### PR DESCRIPTION
## Why
`ingest-utils` 2.1.6 pulls in latest scio; `encode-ingest` is far behind and should be brought up to date.

## This PR
* Upgrades to `ingest-utils` 2.1.6
* Fixes a breaking change when writing json lists
