### PR TITLE
Always notify slack

### DIFF
--- a/orchestration/example-values/no-version.yaml
+++ b/orchestration/example-values/no-version.yaml
@@ -22,6 +22,11 @@ aws:
   credentialsSecretName: shhhhh
 smokeTest:
   enable: false
+notification:
+  onlyOnFailure: false
+  oauthToken:
+    secretName: aaaaa
+    secretKey: bbbbb
 repo:
   url: http://repo!
   datasetId: a

--- a/orchestration/example-values/pinned-version.yaml
+++ b/orchestration/example-values/pinned-version.yaml
@@ -22,6 +22,11 @@ aws:
   credentialsSecretName: shhhhh
 smokeTest:
   enable: false
+notification:
+  onlyOnFailure: false
+  oauthToken:
+    secretName: aaaaa
+    secretKey: bbbbb
 argoTemplates:
   diffBQTable:
     schemaImageVersion: a-pinned-version

--- a/orchestration/example-values/smoke-test.yaml
+++ b/orchestration/example-values/smoke-test.yaml
@@ -22,9 +22,11 @@ aws:
   credentialsSecretName: shhhhh
 smokeTest:
   enable: true
-  slackUrl:
-    secretName: shh
-    secretKey: erl
+notification:
+  onlyOnFailure: false
+  oauthToken:
+    secretName: aaaaa
+    secretKey: bbbbb
 repo:
   url: http://repo!
   datasetId: a

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -14,9 +14,7 @@ spec:
       strategy: OnWorkflowSuccess
     parallelism: {{ .Values.maxParallelism }}
     {{- $smokeTest := .Values.smokeTest.enable }}
-    {{- if $smokeTest }}
     onExit: send-slack-notification
-    {{- end }}
     templates:
       - name: main
         steps:
@@ -28,7 +26,6 @@ spec:
                 parameters:
                   - name: gcs-prefix
                     value: '{{ template "argo.timestamp" }}'
-      {{- if $smokeTest }}
       - name: send-slack-notification
         container:
           image: curlimages/curl:7.70.0
@@ -47,7 +44,8 @@ spec:
             - -XPOST
             - -H
             - 'Content-type: application/json'
+            - -H
+            - 'Authorization: Bearer ${OAUTH_TOKEN}'
             - -d
-            - '{"text": "Workflow $(WORKFLOW_ID) entered state: $(WORKFLOW_STATE)"}'
-            - $(SLACK_URL)
-      {{- end }}
+            - '{"text": "*Encode-ingest {{ if $smokeTest }}(smoke test){{ else }}(prod){{ end }}:* Workflow $(WORKFLOW_ID) entered state: $(WORKFLOW_STATE)", "channel": "monster-ci"}'
+            - "https://slack.com/api/chat.postMessage"

--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -34,11 +34,11 @@ spec:
               value: '{{ "{{workflow.name}}" }}'
             - name: WORKFLOW_STATE
               value: '{{ "{{workflow.status}}" }}'
-            - name: SLACK_URL
+            - name: OAUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.smokeTest.slackUrl.secretName }}
-                  key: {{ .Values.smokeTest.slackUrl.secretKey }}
+                  name: {{ .Values.notification.oauthToken.secretName }}
+                  key: {{ .Values.notification.oauthToken.secretKey }}
           command: [curl]
           args:
             - -XPOST

--- a/orchestration/values.schema.json
+++ b/orchestration/values.schema.json
@@ -71,7 +71,7 @@
     "smokeTest": {
       "type": "object",
        "properties": {
-         "enable": { "type": "boolean" },
+         "enable": { "type": "boolean" }
        },
        "required": ["enable"]
     },

--- a/orchestration/values.schema.json
+++ b/orchestration/values.schema.json
@@ -72,16 +72,23 @@
       "type": "object",
        "properties": {
          "enable": { "type": "boolean" },
-         "slackUrl": {
-           "type": "object",
-           "properties": {
-             "secretName": { "type": "string" },
-             "secretKey": { "type": "string" }
-           },
-           "required": ["secretName", "secretKey"]
-          }
        },
        "required": ["enable"]
+    },
+    "notification": {
+      "type": "object",
+      "properties": {
+        "onlyOnFailure": { "type": "boolean" },
+        "oauthToken": {
+          "type": "object",
+          "properties": {
+            "secretName": { "type": "string" },
+            "secretKey": { "type": "string" }
+          },
+          "required": ["secretName", "secretKey"]
+        }
+      },
+      "required": ["oauthToken"]
     },
     "bigquery": {
       "type": "object",


### PR DESCRIPTION
## Why
We're only pinging slack during our smoke tests; we should ping slack regardless of smoke testing or prod and indicate the environment in the message.

## This PR
* Reworks the slack notification to ping the slack API with a bearer token
* Pulls the token from a new secret in k8s (already in place)