### PR TITLE
Escape the slack oauth token properly

### DIFF
--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -45,7 +45,7 @@ spec:
             - -H
             - 'Content-type: application/json'
             - -H
-            - 'Authorization: Bearer ${OAUTH_TOKEN}'
+            - 'Authorization: Bearer $(OAUTH_TOKEN)'
             - -d
             - '{"text": "*Encode-ingest {{ if $smokeTest }}(smoke test){{ else }}(prod){{ end }}:* Workflow $(WORKFLOW_ID) entered state: $(WORKFLOW_STATE)", "channel": "monster-ci"}'
             - "https://slack.com/api/chat.postMessage"


### PR DESCRIPTION
## Why
Slack notifications are not firing to dev due to improper escaping of the slack oauth token in the onExit handler

## This PR
* Escapes the token properly
