### PR TITLE
[DSPDC-1566] Turn off slack notification

### DIFF
--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -14,7 +14,8 @@ spec:
       strategy: OnWorkflowSuccess
     parallelism: {{ .Values.maxParallelism }}
     {{- $smokeTest := .Values.smokeTest.enable }}
-    onExit: send-slack-notification
+    # TODO: re-enable after DSPDC-1498 lands
+    # onExit: send-slack-notification
     templates:
       - name: main
         steps:


### PR DESCRIPTION
## Why
The Encode ingest is in a known, broken state due to an upstream schema change. The slack notifications are noise until we fix the schema.

## This PR
* Disables the slack notification
