### PR TITLE
[DSPDC-1670] Update to latest ingest-utils to pull in latest graal vm image

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers += Resolver.url(
   new URL("https://broadinstitute.jfrog.io/broadinstitute/libs-release/")
 )(publishPatterns)
 
-addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.6")
+addSbtPlugin("org.broadinstitute.monster" % "ingest-sbt-plugins" % "2.1.9")


### PR DESCRIPTION
## Why
We cannot publish an encode docker image because the base graal vm image has vanished.

## This PR
* Updates to the latest version of ingest-utils which pulls in an updated docker image.
