### PR TITLE
[DSPDC-1498] Re-enable slack notification

### DIFF
--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -14,8 +14,7 @@ spec:
       strategy: OnWorkflowSuccess
     parallelism: {{ .Values.maxParallelism }}
     {{- $smokeTest := .Values.smokeTest.enable }}
-    # TODO: re-enable after DSPDC-1498 lands
-    # onExit: send-slack-notification
+    onExit: send-slack-notification
     templates:
       - name: main
         steps:


### PR DESCRIPTION
We need to reenable the slack notification now that the dev encode ingest is fixed.

