### PR TITLE
Reactivate ENCODE Ingest for DEV TDR

### DIFF
--- a/orchestration/templates/cron-workflow.yaml
+++ b/orchestration/templates/cron-workflow.yaml
@@ -20,7 +20,7 @@ spec:
         steps:
           - - name: run-main-template
               templateRef:
-                name: {{ if $smokeTest }}process-encode-data{{ else }}ingest-encode-data{{ end }}
+                name: ingest-encode-data
                 template: main
               arguments:
                 parameters:


### PR DESCRIPTION
**Why**
We need to reactivate the ENCODE ingest pipeline for DEV TDR.
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1927)

**This PR**
Updated the main template in the encode ingest workflow to ingest data without checking smokeTest.